### PR TITLE
Fix tag extraction in news fetcher

### DIFF
--- a/server/services/news_fetcher.py
+++ b/server/services/news_fetcher.py
@@ -284,7 +284,9 @@ class HVACNewsFetcher:
 
         found_tags: list[str] = []
         for tag in potential_tags:
-            tag_words = tag.lower().replace("hvac", "hvac").split()
+            # Split camel-cased tags (e.g., "SmartHVAC" -> "smart hvac") so each
+            # component can be matched individually within the article text.
+            tag_words = tag.lower().replace("hvac", " hvac").split()
             if all(word in text for word in tag_words):
                 found_tags.append(tag)
 


### PR DESCRIPTION
## Summary
- Split camel-cased tags before matching so words like "SmartHVAC" are detected properly

## Testing
- `npm test` (fails: Missing script)
- `npm run check`


------
https://chatgpt.com/codex/tasks/task_e_689e32b1208883229259cb93e4b6081b