### PR TITLE
Improve news fetching reliability and persistence

### DIFF
--- a/server/storage.ts
+++ b/server/storage.ts
@@ -97,6 +97,23 @@ export class MemStorage implements IStorage {
     }
   }
 
+  private appendArticleToFile(article: Article) {
+    try {
+      fs.mkdirSync(path.dirname(this.dataFilePath), { recursive: true });
+      let articles: Article[] = [];
+      try {
+        const data = fs.readFileSync(this.dataFilePath, "utf8");
+        articles = JSON.parse(data);
+      } catch {
+        // File may not exist or be empty
+      }
+      articles.push(article);
+      fs.writeFileSync(this.dataFilePath, JSON.stringify(articles, null, 2));
+    } catch (error) {
+      console.error("Failed to append article to file:", error);
+    }
+  }
+
   private initializeSampleData() {
     // Create sample articles
     const sampleArticles = [
@@ -374,7 +391,7 @@ export class MemStorage implements IStorage {
       publishedAt: insertArticle.publishedAt ?? new Date()
     };
     this.articles.set(id, article);
-    this.saveArticlesToFile();
+    this.appendArticleToFile(article);
     return article;
   }
 


### PR DESCRIPTION
## Summary
- Skip OpenAI analysis when no API key is configured so news fetch always returns articles
- Append newly fetched articles to `data/news.json` for persistence
- Use a browser User-Agent for Google News RSS requests to avoid empty responses

## Testing
- `npm run check`


------
https://chatgpt.com/codex/tasks/task_e_689e32b1208883229259cb93e4b6081b