### PR TITLE
Persist fetched news to JSON and add frontend fallbacks

### DIFF
--- a/client/src/components/news/news-feed.tsx
+++ b/client/src/components/news/news-feed.tsx
@@ -196,13 +196,15 @@ export default function NewsFeed({ searchQuery, showBookmarked }: NewsFeedProps)
       {/* Articles Grid */}
       <div data-testid="news-feed-articles">
         {articles.length === 0 ? (
-          <Card>
-            <CardContent className="p-8 text-center">
-              <p className="text-muted-foreground" data-testid="text-no-articles">
-                {showBookmarked ? "No bookmarked articles found." : "No articles found matching your filters."}
-              </p>
-            </CardContent>
-          </Card>
+            <Card>
+              <CardContent className="p-8 text-center">
+                <p className="text-muted-foreground" data-testid="text-no-articles">
+                  {showBookmarked
+                    ? "No bookmarked articles found."
+                    : "No articles available. Try fetching news or check back later."}
+                </p>
+              </CardContent>
+            </Card>
         ) : (
           <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 xl:grid-cols-4 2xl:grid-cols-5 gap-6">
             {articles.map((article) => (

--- a/client/src/lib/api.ts
+++ b/client/src/lib/api.ts
@@ -1,6 +1,26 @@
 import { apiRequest } from "./queryClient";
 import { Article, Document, Analytics, AIInsights } from "@/types";
 
+const sampleArticles: Article[] = [
+  {
+    id: 'sample-1',
+    title: 'Sample News Headline',
+    content: 'Sample content for when no news data is available.',
+    summary: 'Sample content for when no news data is available.',
+    source: 'Sample Source',
+    category: 'Industry Analysis',
+    industry: 'HVAC',
+    sentiment: 'neutral',
+    sentimentScore: 0,
+    views: 0,
+    isBookmarked: false,
+    tags: [],
+    aiAnalysis: {},
+    publishedAt: new Date().toISOString(),
+    createdAt: new Date().toISOString()
+  }
+];
+
 export const articlesApi = {
   getArticles: (filters?: {
     category?: string;
@@ -16,7 +36,44 @@ export const articlesApi = {
     if (filters?.search) params.append('search', filters.search);
     if (filters?.bookmarked) params.append('bookmarked', 'true');
 
-    return fetch(`/api/articles?${params}`).then(res => res.json());
+    const applyFilters = (articles: Article[]): Article[] => {
+      return articles.filter(a => {
+        if (filters?.category && a.category !== filters.category) return false;
+        if (filters?.industry && a.industry !== filters.industry) return false;
+        if (filters?.sentiment && a.sentiment !== filters.sentiment.toLowerCase()) return false;
+        if (filters?.search && !a.title.toLowerCase().includes(filters.search.toLowerCase())) return false;
+        if (filters?.bookmarked && !a.isBookmarked) return false;
+        return true;
+      });
+    };
+
+    return fetch('/data/news.json')
+      .then(res => {
+        if (!res.ok) throw new Error('news file missing');
+        return res.json();
+      })
+      .then((data: Article[]) => {
+        if (Array.isArray(data) && data.length > 0) {
+          return applyFilters(data);
+        }
+        return fetch(`/api/articles?${params}`).then(r => r.json());
+      })
+      .then((data: Article[]) => {
+        if (Array.isArray(data) && data.length > 0) {
+          return applyFilters(data);
+        }
+        return sampleArticles;
+      })
+      .catch(async () => {
+        try {
+          const res = await fetch(`/api/articles?${params}`);
+          if (!res.ok) throw new Error('api failed');
+          const apiData: Article[] = await res.json();
+          return apiData.length > 0 ? applyFilters(apiData) : sampleArticles;
+        } catch {
+          return sampleArticles;
+        }
+      });
   },
 
   exportArticles: (filters?: {

--- a/server/index.ts
+++ b/server/index.ts
@@ -1,10 +1,12 @@
 import express, { type Request, Response, NextFunction } from "express";
+import path from "path";
 import { registerRoutes } from "./routes";
 import { setupVite, serveStatic, log } from "./vite";
 
 const app = express();
 app.use(express.json());
 app.use(express.urlencoded({ extended: false }));
+app.use('/data', express.static(path.join(process.cwd(), 'data')));
 
 app.use((req, res, next) => {
   const start = Date.now();

--- a/server/services/news-service.ts
+++ b/server/services/news-service.ts
@@ -1,5 +1,6 @@
 import { spawn } from 'child_process';
 import path from 'path';
+import fs from 'fs';
 import { analyzeArticleSentiment, categorizeArticle } from './openai';
 import type { InsertArticle } from '@shared/schema';
 
@@ -38,7 +39,15 @@ export class NewsService {
 
       // Process articles with AI analysis (or basic processing if AI unavailable)
       const processedArticles = await this.processArticlesWithAI(articles);
-      
+      // Persist fetched articles to JSON file
+      try {
+        const dataPath = path.join(process.cwd(), 'data', 'news.json');
+        fs.mkdirSync(path.dirname(dataPath), { recursive: true });
+        fs.writeFileSync(dataPath, JSON.stringify(processedArticles, null, 2));
+      } catch (err) {
+        console.error('Failed to write news data file:', err);
+      }
+
       console.log(`Successfully processed ${processedArticles.length} articles`);
       return processedArticles;
 


### PR DESCRIPTION
## Summary
- persist processed news articles to `data/news.json`
- serve the `data` directory statically for client access
- fetch news from JSON with API fallback and sample articles on failure
- show a helpful message when no articles are available

## Testing
- `npm test` (fails: Missing script: "test")
- `npm run check`

------
https://chatgpt.com/codex/tasks/task_e_689ee094c4108322b252af0209589d62